### PR TITLE
Solution / with a small bug report

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ The `App`contains a `MoviesList` and a search field. Implement filtering using a
 - Implement a solution following the [React task guideline](https://github.com/mate-academy/react_task-guideline#react-tasks-guideline).
 - Use the [React TypeScript cheat sheet](https://mate-academy.github.io/fe-program/js/extra/react-typescript).
 - Open one more terminal and run tests with `npm test` to ensure your solution is correct.
-- Replace `<your_account>` with your Github username in the [DEMO LINK](https://<your_account>.github.io/react_movies-list-filter/) and add it to the PR description.
+- Replace `<your_account>` with your Github username in the [DEMO LINK](https://UmizDemud.github.io/react_movies-list-filter/) and add it to the PR description.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.scss';
 import { MoviesList } from './components/MoviesList';
 import moviesFromServer from './api/movies.json';
+import { Movie } from './types/Movie';
 
 export const App: React.FC = () => {
+  const [query, setQuery] = useState('');
+
+  const queryLowerCase = query.trim().toLowerCase();
+  const visibleMovies: Movie[] = moviesFromServer.filter(
+    movie => movie.title.toLowerCase().includes(queryLowerCase)
+      || movie.description.toLowerCase().includes(queryLowerCase),
+  );
+
   return (
     <div className="page">
       <div className="page-content">
@@ -20,12 +29,16 @@ export const App: React.FC = () => {
                 id="search-query"
                 className="input"
                 placeholder="Type search word"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                }}
               />
             </div>
           </div>
         </div>
 
-        <MoviesList movies={moviesFromServer} />
+        <MoviesList movies={visibleMovies} />
       </div>
 
       <div className="sidebar">

--- a/src/components/MovieCard/MovieCard.tsx
+++ b/src/components/MovieCard/MovieCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Movie } from '../../types/Movie';
 import './MovieCard.scss';
 
 interface Props {

--- a/src/components/MoviesList/MoviesList.tsx
+++ b/src/components/MoviesList/MoviesList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './MoviesList.scss';
 import { MovieCard } from '../MovieCard';
+import { Movie } from '../../types/Movie';
 
 interface Props {
   movies: Movie[];

--- a/src/types/Movie.ts
+++ b/src/types/Movie.ts
@@ -1,0 +1,7 @@
+export type Movie = {
+  title: string;
+  description: string;
+  imgUrl: string;
+  imdbUrl: string;
+  imdbId: string;
+};


### PR DESCRIPTION
[DEMO LINK](https://UmizDemud.github.io/react_movies-list-filter/)

A small bug in the tests found and fixed.
In directory /cypress/integration/page.spec.js

Line 114:

```js
  it('should update search results on type', () => {
    page.searchField().type('l');
    page.movies().should('have.length', 5);

    page.searchField().type('o'); // Changed from 'lo' to 'o'
    page.movies().should('have.length', 4);

    page.searchField().type('ve'); // Changed from 'love' to 've'
    page.movies().should('have.length', 3);
  });
```

as the search bar already have the letter 'l' in it, writing *'lo'* makes it '*llo*'

search bar isn't cleared withing the same text in consecutive 'type' actions. 

So I made it that it only types 'l', 'o', 've'. Therefore it searches for the scenario correctly.