### PR TITLE
movies list filter was implemented

### DIFF
--- a/cypress/integration/page.spec.js
+++ b/cypress/integration/page.spec.js
@@ -115,10 +115,10 @@ describe('Page', () => {
     page.searchField().type('l');
     page.movies().should('have.length', 5);
 
-    page.searchField().type('lo');
+    page.searchField().type('o');
     page.movies().should('have.length', 4);
 
-    page.searchField().type('love');
+    page.searchField().type('ve');
     page.movies().should('have.length', 3);
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ export const App: React.FC = () => {
     const normalizedQuery = query
       .toLowerCase()
       .split(' ')
-      .filter(element => element.length > 0)
+      .filter(Boolean)
       .join(' ');
 
     return stringToCheck.includes(normalizedQuery);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.scss';
 import { MoviesList } from './components/MoviesList';
 import moviesFromServer from './api/movies.json';
 
 export const App: React.FC = () => {
+  const [query, setQuery] = useState('');
+
+  const visibleMovies = moviesFromServer.filter(movie => {
+    const stringToCheck = `${movie.title} ${movie.description}`.toLowerCase();
+    const normalizedQuery = query
+      .toLowerCase()
+      .split(' ')
+      .filter(element => element.length > 0)
+      .join(' ');
+
+    return stringToCheck.includes(normalizedQuery);
+  });
+
   return (
     <div className="page">
       <div className="page-content">
@@ -20,12 +33,16 @@ export const App: React.FC = () => {
                 id="search-query"
                 className="input"
                 placeholder="Type search word"
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                }}
               />
             </div>
           </div>
         </div>
 
-        <MoviesList movies={moviesFromServer} />
+        <MoviesList movies={visibleMovies} />
       </div>
 
       <div className="sidebar">


### PR DESCRIPTION
[DEMO LINK](https://Oleksandr-Filo.github.io/react_movies-list-filter/)

I found and fixed a bug in tests:
- directory - cypress/integration/page.spec.js
- test No 14 line 114
```
  it('should update search results on type', () => {
    page.searchField().type('l');
    page.movies().should('have.length', 5);

    page.searchField().type('o'); // Changed from 'lo' to 'o'
    page.movies().should('have.length', 4);

    page.searchField().type('ve'); // Changed from 'love' to 've'
    page.movies().should('have.length', 3);
  });
```
I decided to change these parameters because in this test the search field is not clearing and when we try to check length in the second part of the test (type('lo')) input value becomes 'llo' and the test works incorrectly. The same happens with the last part of the test.